### PR TITLE
Add: .github templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Ping these folks when changes are made to this repository
+* @felicianotech

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,25 @@
+### Prerequisites
+
+* [ ] Are you running the latest version?
+* [ ] Did you check for similar issues on github?
+
+
+### Description
+
+<!-- If this a feature Request, kindly replace the below requirements with your suggestions -->
+
+[Description of the bug or feature]
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expected to happen]
+
+**Actual behavior:** [What actually happened]
+
+### Versions
+
+Specify the current orb version you are using. eg: `0.1.2`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.


### PR DESCRIPTION
 Also added `CODEOWNERS` file. 

closes https://github.com/CircleCI-Public/os-detect-orb/issues/7